### PR TITLE
kuksa-test-client: config: require pylibs layer

### DIFF
--- a/kuksa-test-client/meta/config.yaml
+++ b/kuksa-test-client/meta/config.yaml
@@ -114,6 +114,7 @@ configuration:
     # List of layers. Each layer identified by strict alias. For example, python-3.6.8, rust-x.y.z.
     layers:
         - "aos-kuksa-client-layer"
+        - "aos-pylibs-layer"
 # State configuration:
 #    state:
 #        filename: state.dat


### PR DESCRIPTION
This patch adds second layer 'aos-pylibs-layer' to demo the ability to use multiple layers in a service.
Also, the test client contains code that requires the aos-pylibs-layer to be present.